### PR TITLE
Some small fixes for the ruby images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
 FROM ruby:latest
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  libpq-dev \
+  libgmp-dev
+RUN gem install bundler
 ADD ./Gemfile ./Gemfile
 RUN bundle install
 ADD . /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ postgres:
 redis:
   image: redis
   volumes:
-    - /var/lib/docker/speak_data/redis:/data
+    - /var/lib/docker/pushbit_data/redis:/data
   ports:
     - "6379:6379"
 


### PR DESCRIPTION
I had some problems building the default Dockerfile image. The bundle
command wasnt found and some of the gems failed to install. Perhaps
bundler is not included with the ruby:latest image anymore. But the pg
and json gem failed to install due to missing system dependencies.

Also I removed a reference to speak.