### PR TITLE
make redis and posgres not use public elb

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 database:
   image: postgres:9.5
   ports:
-    - "5432:5432"
+    - 5432
   environment:
     POSTGRES_USER: postgres
     POSTGRES_PASSWORD: password
@@ -9,7 +9,7 @@ database:
 redis:
   image: redis
   ports:
-    - "6379:6379"
+    - 6379
 
 platform:
   build: .


### PR DESCRIPTION
we could probably do with removing the 5000 endpoint eventually as that is creating an elb we don't need